### PR TITLE
Added write-only operation

### DIFF
--- a/examples/demo_with_stm32f411/src/bin/demo_parallel_interface.rs
+++ b/examples/demo_with_stm32f411/src/bin/demo_parallel_interface.rs
@@ -29,7 +29,7 @@ use stm32f4xx_hal::{pac, prelude::*};
 
 use lcd1602_driver::{
     command::{DataWidth, MoveDirection, State},
-    lcd::{self, Anim, Basic, Ext, FlipStyle, Lcd, MoveStyle},
+    lcd::{self, Anim, Basic, Ext, ExtRead, FlipStyle, Lcd, MoveStyle},
     sender::ParallelSender,
     utils::BitOps,
 };

--- a/examples/demo_with_stm32f411/src/bin/demo_parallel_interface_write_only.rs
+++ b/examples/demo_with_stm32f411/src/bin/demo_parallel_interface_write_only.rs
@@ -1,18 +1,36 @@
+//! Drive LCD1602 with a STM32F411RET6 in 4 Pin Mode
+//!
+//! this demo use many different read/write functions intentionally, to test functions works just fine.
+
+//! Wiring diagram
+//!
+//! LCD1602 <-> STM32F411RET6
+//!     Vss <-> GND
+//!     Vdd <-> 5V (It is best to use an external source for the 5V pin, such as the 5V output from a DAPLink device or USB.)
+//!      V0 <-> potentiometer <-> 5V & GND (to adjust the display contrast)
+//!      RS <-> PA0
+//!      RW <-> PA1
+//!      EN <-> PA2 (and optionally connect to a 4.7 kOhm Pulldown resistor, to stable voltage level when STM32 reset)
+//!      D4 <-> PA3
+//!      D5 <-> PA4
+//!      D6 <-> PA5
+//!      D7 <-> PA6
+//!       A <-> 5V
+//!       K <-> external NPN transistor collector
+//!     external NPN transistor base <-> PA7
+//!     external NPN transistor emitter <-> GND
+
 #![no_std]
 #![no_main]
 
 use panic_rtt_target as _;
 use rtt_target::rtt_init_print;
-use stm32f4xx_hal::{
-    i2c::{self, I2c},
-    pac,
-    prelude::*,
-};
+use stm32f4xx_hal::{pac, prelude::*};
 
 use lcd1602_driver::{
     command::{DataWidth, MoveDirection, State},
-    lcd::{self, Anim, Basic, BasicRead, Ext, ExtRead, FlipStyle, Lcd, MoveStyle},
-    sender::I2cSender,
+    lcd::{self, Anim, Basic, Ext, FlipStyle, Lcd, MoveStyle},
+    sender::ParallelSender,
     utils::BitOps,
 };
 
@@ -35,32 +53,55 @@ fn main() -> ! {
 
     // init needed digital pins
 
-    let gpiob = dp.GPIOB.split();
+    let gpioa = dp.GPIOA.split();
 
-    let mut i2c = I2c::new(
-        dp.I2C1,
-        (gpiob.pb6, gpiob.pb7),
-        i2c::Mode::standard(100.kHz()), // The PCF8574T max I2C speed
-        &clocks,
-    );
+    // Push-pull mode for a fast interaction
+    let rs_pin = gpioa.pa0.into_push_pull_output().erase();
+    let rw_pin = gpioa.pa1.into_push_pull_output().erase();
+    let en_pin = gpioa.pa2.into_push_pull_output().erase();
+
+    let db4_pin = gpioa
+        .pa3
+        .into_open_drain_output()
+        .internal_pull_up(true)
+        .erase();
+    let db5_pin = gpioa
+        .pa4
+        .into_open_drain_output()
+        .internal_pull_up(true)
+        .erase();
+    let db6_pin = gpioa
+        .pa5
+        .into_open_drain_output()
+        .internal_pull_up(true)
+        .erase();
+    let db7_pin = gpioa
+        .pa6
+        .into_open_drain_output()
+        .internal_pull_up(true)
+        .erase();
+
+    let bl_pin = gpioa.pa7.into_push_pull_output().erase();
 
     // put pins together
-    let mut sender = I2cSender::new(&mut i2c, 0x27);
+    let mut sender = ParallelSender::new_4pin(
+        rs_pin,
+        rw_pin,
+        en_pin,
+        db4_pin,
+        db5_pin,
+        db6_pin,
+        db7_pin,
+        Some(bl_pin),
+    );
 
     let lcd_config = lcd::Config::default().set_data_width(DataWidth::Bit4);
 
-    // create and init LCD1602
+    // init LCD1602
     let mut lcd = Lcd::new(&mut sender, &mut delayer, lcd_config, 10);
 
     // draw a little heart in CGRAM
     lcd.write_graph_to_cgram(1, &HEART);
-
-    // to test cgram read
-    // read heart graph from CGRAM, modify it to a diamond shape, then write it to another CGRAM address
-    let mut graph_data = lcd.read_graph_from_cgram(1);
-    graph_data[1].set_bit(2);
-    graph_data[2].set_bit(2);
-    lcd.write_graph_to_cgram(2, &graph_data);
 
     lcd.set_cursor_blink_state(State::On);
 
@@ -122,11 +163,6 @@ fn main() -> ! {
     lcd.write_graph_to_pos(1, (15, 0));
     lcd.delay_ms(1_000);
     lcd.write_graph_to_pos(2, (15, 1));
-
-    // to test read from DDRAM
-    // read from first line end, and write same character to the second line end
-    let char_at_end = lcd.read_byte_from_pos((39, 0));
-    lcd.write_byte_to_pos(char_at_end, (39, 1));
 
     // shift display window
     lcd.delay_ms(1_000);

--- a/src/lcd.rs
+++ b/src/lcd.rs
@@ -14,7 +14,7 @@ pub use init::Config;
 mod impls;
 
 /// [`Lcd`] is the main struct to drive a LCD1602
-pub struct Lcd<'a, 'b, Sender, Delayer>
+pub struct Lcd<'a, 'b, Sender, Delayer, const READABLE: bool>
 where
     Delayer: DelayNs,
 {
@@ -27,8 +27,6 @@ where
 /// All basic command to control LCD1602
 #[allow(missing_docs)]
 pub trait Basic {
-    fn read_u8_from_cur(&mut self) -> u8;
-
     fn write_u8_to_cur(&mut self, byte: u8);
 
     fn write_graph_to_cgram(&mut self, index: u8, graph_data: &[u8; 8]);
@@ -100,6 +98,12 @@ pub trait Basic {
     fn delay_us(&mut self, us: u32);
 }
 
+/// Basic read functions for the LCD
+#[allow(missing_docs)]
+pub trait BasicRead: Basic {
+    fn read_u8_from_cur(&mut self) -> u8;
+}
+
 /// Useful command to control LCD1602
 pub trait Ext: Basic {
     /// toggle entire display on and off (it doesn't toggle backlight)
@@ -140,15 +144,6 @@ pub trait Ext: Basic {
         self.write_u8_to_cur(byte);
     }
 
-    /// read a byte from specific position
-    fn read_byte_from_pos(&mut self, pos: (u8, u8)) -> u8 {
-        let original_pos = self.get_cursor_pos();
-        self.set_cursor_pos(pos);
-        let data = self.read_u8_from_cur();
-        self.set_cursor_pos(original_pos);
-        data
-    }
-
     /// write a char to specific position
     fn write_char_to_pos(&mut self, char: char, pos: (u8, u8)) {
         self.set_cursor_pos(pos);
@@ -167,6 +162,23 @@ pub trait Ext: Basic {
         self.write_byte_to_pos(index, pos);
     }
 
+    /// change cursor position with relative offset
+    fn offset_cursor_pos(&mut self, offset: (i8, i8)) {
+        self.set_cursor_pos(self.calculate_pos_by_offset(self.get_cursor_pos(), offset));
+    }
+}
+
+/// Useful commands to read data from the LCD
+pub trait ExtRead: Ext + BasicRead {
+    /// read a byte from specific position
+    fn read_byte_from_pos(&mut self, pos: (u8, u8)) -> u8 {
+        let original_pos = self.get_cursor_pos();
+        self.set_cursor_pos(pos);
+        let data = self.read_u8_from_cur();
+        self.set_cursor_pos(original_pos);
+        data
+    }
+
     /// read custom graph data from CGRAM
     fn read_graph_from_cgram(&mut self, index: u8) -> [u8; 8] {
         assert!(index < 8, "index too big, should less than 8");
@@ -181,11 +193,6 @@ pub trait Ext: Basic {
             .for_each(|line| *line = self.read_u8_from_cur());
 
         graph
-    }
-
-    /// change cursor position with relative offset
-    fn offset_cursor_pos(&mut self, offset: (i8, i8)) {
-        self.set_cursor_pos(self.calculate_pos_by_offset(self.get_cursor_pos(), offset));
     }
 }
 

--- a/src/lcd/impls.rs
+++ b/src/lcd/impls.rs
@@ -4,11 +4,11 @@ use crate::command::{DataWidth, Font, LineMode, MoveDirection, RAMType, ShiftTyp
 use crate::sender::SendCommand;
 use crate::{command::CommandSet, lcd::State};
 
-use super::{Anim, Basic, Ext, Lcd};
+use super::{Anim, Basic, BasicRead, Ext, ExtRead, Lcd};
 
-impl<'a, 'b, Sender, Delayer> Basic for Lcd<'a, 'b, Sender, Delayer>
+impl<'a, 'b, Sender, Delayer, const READABLE: bool> Basic for Lcd<'a, 'b, Sender, Delayer, READABLE>
 where
-    Sender: SendCommand<Delayer>,
+    Sender: SendCommand<Delayer, READABLE>,
     Delayer: DelayNs,
 {
     fn set_backlight(&mut self, backlight: State) {
@@ -18,16 +18,6 @@ where
 
     fn get_backlight(self) -> State {
         self.state.get_backlight()
-    }
-
-    fn read_u8_from_cur(&mut self) -> u8 {
-        self.sender
-            .wait_and_send(
-                CommandSet::ReadDataFromRAM.into(),
-                self.delayer,
-                self.poll_interval_us,
-            )
-            .unwrap()
     }
 
     fn write_u8_to_cur(&mut self, byte: u8) {
@@ -316,16 +306,39 @@ where
     }
 }
 
-impl<'a, 'b, Sender, Delayer> Ext for Lcd<'a, 'b, Sender, Delayer>
+impl<'a, 'b, Sender, Delayer> BasicRead for Lcd<'a, 'b, Sender, Delayer, true>
+where
+    Sender: SendCommand<Delayer, true>,
+    Delayer: DelayNs,
+{
+    fn read_u8_from_cur(&mut self) -> u8 {
+        self.sender
+            .wait_and_send(
+                CommandSet::ReadDataFromRAM.into(),
+                self.delayer,
+                self.poll_interval_us,
+            )
+            .unwrap()
+    }
+}
+
+impl<'a, 'b, Sender, Delayer, const READABLE: bool> Ext for Lcd<'a, 'b, Sender, Delayer, READABLE>
 where
     Delayer: DelayNs,
-    Sender: SendCommand<Delayer>,
+    Sender: SendCommand<Delayer, READABLE>,
 {
 }
 
-impl<'a, 'b, Sender, Delayer> Anim for Lcd<'a, 'b, Sender, Delayer>
+impl<'a, 'b, Sender, Delayer> ExtRead for Lcd<'a, 'b, Sender, Delayer, true>
 where
     Delayer: DelayNs,
-    Sender: SendCommand<Delayer>,
+    Sender: SendCommand<Delayer, true>,
+{
+}
+
+impl<'a, 'b, Sender, Delayer, const READABLE: bool> Anim for Lcd<'a, 'b, Sender, Delayer, READABLE>
+where
+    Delayer: DelayNs,
+    Sender: SendCommand<Delayer, READABLE>,
 {
 }

--- a/src/lcd/init.rs
+++ b/src/lcd/init.rs
@@ -128,9 +128,112 @@ impl Config {
     }
 }
 
-impl<'a, 'b, Sender, Delayer, const READABLE: bool> Lcd<'a, 'b, Sender, Delayer, READABLE>
+fn lcd_init<'a, 'b, Sender, Delayer, const READABLE: bool>(
+    sender: &'a mut Sender,
+    delayer: &'b mut Delayer,
+    config: Config,
+    poll_interval_us: u32,
+) -> Lcd<'a, 'b, Sender, Delayer, READABLE>
 where
     Sender: SendCommand<Delayer, READABLE>,
+    Delayer: DelayNs,
+{
+    let state = config.state;
+
+    // in initialization process, we'd better use "raw command", to strictly follow datasheet
+
+    // only first 2 or 3 commands are different between 4 pin and 8 pin mode
+    match state.get_data_width() {
+        DataWidth::Bit4 => {
+            sender.delay_and_send(CommandSet::HalfFunctionSet.into(), delayer, 40_000);
+
+            sender.delay_and_send(
+                CommandSet::FunctionSet(DataWidth::Bit4, state.get_line_mode(), state.get_font())
+                    .into(),
+                delayer,
+                40,
+            );
+
+            sender.delay_and_send(
+                CommandSet::FunctionSet(DataWidth::Bit4, state.get_line_mode(), state.get_font())
+                    .into(),
+                delayer,
+                40,
+            );
+        }
+
+        DataWidth::Bit8 => {
+            sender.delay_and_send(
+                CommandSet::FunctionSet(DataWidth::Bit8, state.get_line_mode(), state.get_font())
+                    .into(),
+                delayer,
+                40_000,
+            );
+
+            sender.delay_and_send(
+                CommandSet::FunctionSet(DataWidth::Bit8, state.get_line_mode(), state.get_font())
+                    .into(),
+                delayer,
+                40,
+            );
+        }
+    }
+
+    sender.wait_and_send(
+        CommandSet::DisplayOnOff {
+            display: state.get_display_state(),
+            cursor: state.get_cursor_state(),
+            cursor_blink: state.get_cursor_blink(),
+        }
+        .into(),
+        delayer,
+        poll_interval_us,
+    );
+
+    sender.wait_and_send(CommandSet::ClearDisplay.into(), delayer, poll_interval_us);
+
+    // Accroding to ST6077U datasheet, after CommandSet::ClearDisplay we will need to manually
+    // wait at least 1.52 ms before send CommandSet::EntryModeSet
+    // This only needs to happen if we don't know when the command finishes (aka not readable)
+    if !READABLE {
+        delayer.delay_us(1520);
+    }
+
+    sender.wait_and_send(
+        CommandSet::EntryModeSet(state.get_direction(), state.get_shift_type()).into(),
+        delayer,
+        poll_interval_us,
+    );
+
+    // set backlight after LCD init
+    sender.set_backlight(state.get_backlight());
+
+    Lcd {
+        sender,
+        delayer,
+        state,
+        poll_interval_us,
+    }
+}
+
+impl<'a, 'b, Sender, Delayer> Lcd<'a, 'b, Sender, Delayer, false>
+where
+    Sender: SendCommand<Delayer, false>,
+    Delayer: DelayNs,
+{
+    /// Create a [`Lcd`] driver, and init LCD hardware
+    pub fn new_write_only(
+        sender: &'a mut Sender,
+        delayer: &'b mut Delayer,
+        config: Config,
+    ) -> Self {
+        lcd_init(sender, delayer, config, 0)
+    }
+}
+
+impl<'a, 'b, Sender, Delayer> Lcd<'a, 'b, Sender, Delayer, true>
+where
+    Sender: SendCommand<Delayer, true>,
     Delayer: DelayNs,
 {
     /// Create a [`Lcd`] driver, and init LCD hardware
@@ -140,90 +243,6 @@ where
         config: Config,
         poll_interval_us: u32,
     ) -> Self {
-        let state = config.state;
-
-        // in initialization process, we'd better use "raw command", to strictly follow datasheet
-
-        // only first 2 or 3 commands are different between 4 pin and 8 pin mode
-        match state.get_data_width() {
-            DataWidth::Bit4 => {
-                sender.delay_and_send(CommandSet::HalfFunctionSet.into(), delayer, 40_000);
-
-                sender.delay_and_send(
-                    CommandSet::FunctionSet(
-                        DataWidth::Bit4,
-                        state.get_line_mode(),
-                        state.get_font(),
-                    )
-                    .into(),
-                    delayer,
-                    40,
-                );
-
-                sender.delay_and_send(
-                    CommandSet::FunctionSet(
-                        DataWidth::Bit4,
-                        state.get_line_mode(),
-                        state.get_font(),
-                    )
-                    .into(),
-                    delayer,
-                    40,
-                );
-            }
-
-            DataWidth::Bit8 => {
-                sender.delay_and_send(
-                    CommandSet::FunctionSet(
-                        DataWidth::Bit8,
-                        state.get_line_mode(),
-                        state.get_font(),
-                    )
-                    .into(),
-                    delayer,
-                    40_000,
-                );
-
-                sender.delay_and_send(
-                    CommandSet::FunctionSet(
-                        DataWidth::Bit8,
-                        state.get_line_mode(),
-                        state.get_font(),
-                    )
-                    .into(),
-                    delayer,
-                    40,
-                );
-            }
-        }
-
-        sender.wait_and_send(
-            CommandSet::DisplayOnOff {
-                display: state.get_display_state(),
-                cursor: state.get_cursor_state(),
-                cursor_blink: state.get_cursor_blink(),
-            }
-            .into(),
-            delayer,
-            poll_interval_us,
-        );
-
-        sender.wait_and_send(CommandSet::ClearDisplay.into(), delayer, poll_interval_us);
-
-        sender.wait_and_send(
-            CommandSet::EntryModeSet(state.get_direction(), state.get_shift_type()).into(),
-            delayer,
-            poll_interval_us,
-        );
-
-        // set backlight after LCD init
-        sender.set_backlight(state.get_backlight());
-
-        Lcd {
-            sender,
-            delayer,
-            state,
-            poll_interval_us,
-        }
+        lcd_init(sender, delayer, config, poll_interval_us)
     }
 }

--- a/src/lcd/init.rs
+++ b/src/lcd/init.rs
@@ -128,9 +128,9 @@ impl Config {
     }
 }
 
-impl<'a, 'b, Sender, Delayer> Lcd<'a, 'b, Sender, Delayer>
+impl<'a, 'b, Sender, Delayer, const READABLE: bool> Lcd<'a, 'b, Sender, Delayer, READABLE>
 where
-    Sender: SendCommand<Delayer>,
+    Sender: SendCommand<Delayer, READABLE>,
     Delayer: DelayNs,
 {
     /// Create a [`Lcd`] driver, and init LCD hardware

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,4 +1,4 @@
-//! Built-in sender  
+//! Built-in sender
 //! If you want to create a new sender, you will need to implement [`SendCommand`] trait
 
 use embedded_hal::delay::DelayNs;
@@ -15,7 +15,7 @@ pub use i2c_sender::I2cSender;
 pub use parallel_sender::ParallelSender;
 
 /// [`SendCommand`] is the trait a sender should implement to communicate with the hardware
-pub trait SendCommand<Delayer: DelayNs> {
+pub trait SendCommand<Delayer: DelayNs, const READABLE: bool> {
     /// Parse a [`Command`] and sending data to hardware,
     /// and return the result value when [`Command`] is a [`ReadWriteOp::Read`](crate::command::ReadWriteOp::Read) command
     fn send(&mut self, command: Command) -> Option<u8>;

--- a/src/sender/i2c_sender.rs
+++ b/src/sender/i2c_sender.rs
@@ -40,7 +40,7 @@ impl<'a, I2cLcd: I2c<A>, A: AddressMode + Clone> I2cSender<'a, I2cLcd, A> {
     }
 }
 
-impl<'a, I2cLcd, A, Delayer> SendCommand<Delayer> for I2cSender<'a, I2cLcd, A>
+impl<'a, I2cLcd, A, Delayer> SendCommand<Delayer, true> for I2cSender<'a, I2cLcd, A>
 where
     I2cLcd: I2c<A>,
     A: AddressMode + Clone,
@@ -195,6 +195,7 @@ impl From<Command> for I2cRawData {
     }
 }
 
+#[allow(dead_code)]
 struct I2cSeq(u8, [u8; 6]);
 
 impl From<I2cRawData> for I2cSeq {

--- a/src/sender/parallel_sender.rs
+++ b/src/sender/parallel_sender.rs
@@ -12,27 +12,33 @@ use crate::{
 
 use super::SendCommand;
 
+pub trait IfReadable<const READABLE: bool> {}
+
+impl<T> IfReadable<false> for T where T: OutputPin {}
+
+impl<T> IfReadable<true> for T where T: OutputPin + InputPin {}
+
 /// [`ParallelSender`] is the parallel interface to drive LCD1602
-pub struct ParallelSender<ControlPin, DBPin, BLPin, const PIN_CNT: usize>
+pub struct ParallelSender<ControlPin, DBPin, BLPin, const PIN_CNT: usize, const READABLE: bool>
 where
     ControlPin: OutputPin,
-    DBPin: OutputPin + InputPin,
+    DBPin: OutputPin + IfReadable<READABLE>,
     BLPin: StatefulOutputPin,
 {
     rs_pin: ControlPin,
-    rw_pin: ControlPin,
+    rw_pin: Option<ControlPin>,
     en_pin: ControlPin,
     db_pins: [DBPin; PIN_CNT],
     bl_pin: Option<BLPin>,
 }
 
-impl<ControlPin, DBPin, BLPin> ParallelSender<ControlPin, DBPin, BLPin, 4>
+impl<ControlPin, DBPin, BLPin> ParallelSender<ControlPin, DBPin, BLPin, 4, true>
 where
     ControlPin: OutputPin,
     DBPin: OutputPin + InputPin,
     BLPin: StatefulOutputPin,
 {
-    /// Create 4-pin parallel driver, will need other 3 pins to control LCD,  
+    /// Create 4-pin parallel driver, will need other 3 pins to control LCD,
     /// and a optional pin to control backlight (better connect the pin to a transistor)
     #[allow(clippy::too_many_arguments)]
     pub fn new_4pin(
@@ -47,7 +53,7 @@ where
     ) -> Self {
         Self {
             rs_pin: rs,
-            rw_pin: rw,
+            rw_pin: Some(rw),
             en_pin: en,
             db_pins: [db4, db5, db6, db7],
             bl_pin: bl,
@@ -55,13 +61,41 @@ where
     }
 }
 
-impl<ControlPin, DBPin, BLPin> ParallelSender<ControlPin, DBPin, BLPin, 8>
+impl<ControlPin, DBPin, BLPin> ParallelSender<ControlPin, DBPin, BLPin, 4, false>
+where
+    ControlPin: OutputPin,
+    DBPin: OutputPin,
+    BLPin: StatefulOutputPin,
+{
+    /// Create 4-pin parallel driver, will need other 2 pins to control LCD,
+    /// and a optional pin to control backlight (better connect the pin to a transistor)
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_4pin_write_only(
+        rs: ControlPin,
+        en: ControlPin,
+        db4: DBPin,
+        db5: DBPin,
+        db6: DBPin,
+        db7: DBPin,
+        bl: Option<BLPin>,
+    ) -> Self {
+        Self {
+            rs_pin: rs,
+            rw_pin: None,
+            en_pin: en,
+            db_pins: [db4, db5, db6, db7],
+            bl_pin: bl,
+        }
+    }
+}
+
+impl<ControlPin, DBPin, BLPin> ParallelSender<ControlPin, DBPin, BLPin, 8, true>
 where
     ControlPin: OutputPin,
     DBPin: OutputPin + InputPin,
     BLPin: StatefulOutputPin,
 {
-    /// Create 8-pin parallel driver, will need other 3 pins to control LCD,  
+    /// Create 8-pin parallel driver, will need other 3 pins to control LCD,
     /// and a optional pin to control backlight (better connect the pin to a transistor)
     #[allow(clippy::too_many_arguments)]
     pub fn new_8pin(
@@ -80,7 +114,7 @@ where
     ) -> Self {
         Self {
             rs_pin: rs,
-            rw_pin: rw,
+            rw_pin: Some(rw),
             en_pin: en,
             db_pins: [db0, db1, db2, db3, db4, db5, db6, db7],
             bl_pin: bl,
@@ -88,25 +122,72 @@ where
     }
 }
 
+impl<ControlPin, DBPin, BLPin> ParallelSender<ControlPin, DBPin, BLPin, 8, false>
+where
+    ControlPin: OutputPin,
+    DBPin: OutputPin,
+    BLPin: StatefulOutputPin,
+{
+    /// Create 8-pin parallel driver, will need other 2 pins to control LCD,
+    /// and a optional pin to control backlight (better connect the pin to a transistor)
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_8pin_write_only(
+        rs: ControlPin,
+        en: ControlPin,
+        db0: DBPin,
+        db1: DBPin,
+        db2: DBPin,
+        db3: DBPin,
+        db4: DBPin,
+        db5: DBPin,
+        db6: DBPin,
+        db7: DBPin,
+        bl: Option<BLPin>,
+    ) -> Self {
+        Self {
+            rs_pin: rs,
+            rw_pin: None,
+            en_pin: en,
+            db_pins: [db0, db1, db2, db3, db4, db5, db6, db7],
+            bl_pin: bl,
+        }
+    }
+}
+
+fn push_bits<const PIN_CNT: usize, DBPin: OutputPin>(pins: &mut [DBPin; PIN_CNT], raw_bits: u8) {
+    pins.iter_mut()
+        .enumerate()
+        .for_each(|(index, pin)| match raw_bits.check_bit(index as u8) {
+            BitState::Set => {
+                pin.set_high().ok().unwrap();
+            }
+            BitState::Clear => {
+                pin.set_low().ok().unwrap();
+            }
+        });
+}
+
 impl<ControlPin, DBPin, BLPin, const PIN_CNT: usize>
-    ParallelSender<ControlPin, DBPin, BLPin, PIN_CNT>
+    ParallelSender<ControlPin, DBPin, BLPin, PIN_CNT, false>
+where
+    ControlPin: OutputPin,
+    DBPin: OutputPin,
+    BLPin: StatefulOutputPin,
+{
+    fn push_bits(&mut self, raw_bits: u8) {
+        push_bits(&mut self.db_pins, raw_bits);
+    }
+}
+
+impl<ControlPin, DBPin, BLPin, const PIN_CNT: usize>
+    ParallelSender<ControlPin, DBPin, BLPin, PIN_CNT, true>
 where
     ControlPin: OutputPin,
     DBPin: OutputPin + InputPin,
     BLPin: StatefulOutputPin,
 {
     fn push_bits(&mut self, raw_bits: u8) {
-        self.db_pins
-            .iter_mut()
-            .enumerate()
-            .for_each(|(index, pin)| match raw_bits.check_bit(index as u8) {
-                BitState::Set => {
-                    pin.set_high().ok().unwrap();
-                }
-                BitState::Clear => {
-                    pin.set_low().ok().unwrap();
-                }
-            });
+        push_bits(&mut self.db_pins, raw_bits);
     }
 
     fn fetch_bits(&mut self) -> u8 {
@@ -130,32 +211,38 @@ where
     }
 }
 
-impl<ControlPin, DBPin, BLPin, const PIN_CNT: usize, Delayer> SendCommand<Delayer>
-    for ParallelSender<ControlPin, DBPin, BLPin, PIN_CNT>
+macro_rules! backlight_fns {
+    () => {
+        fn get_backlight(&mut self) -> State {
+            match self.bl_pin.as_mut() {
+                Some(bl_pin) => match bl_pin.is_set_high().unwrap() {
+                    true => State::On,
+                    false => State::Off,
+                },
+                None => Default::default(),
+            }
+        }
+
+        fn set_backlight(&mut self, backlight: State) {
+            if let Some(bl_pin) = self.bl_pin.as_mut() {
+                match backlight {
+                    State::Off => bl_pin.set_low().unwrap(),
+                    State::On => bl_pin.set_high().unwrap(),
+                }
+            }
+        }
+    };
+}
+
+impl<ControlPin, DBPin, BLPin, const PIN_CNT: usize, Delayer> SendCommand<Delayer, true>
+    for ParallelSender<ControlPin, DBPin, BLPin, PIN_CNT, true>
 where
     ControlPin: OutputPin,
     DBPin: OutputPin + InputPin,
     BLPin: StatefulOutputPin,
     Delayer: DelayNs,
 {
-    fn get_backlight(&mut self) -> State {
-        match self.bl_pin.as_mut() {
-            Some(bl_pin) => match bl_pin.is_set_high().unwrap() {
-                true => State::On,
-                false => State::Off,
-            },
-            None => Default::default(),
-        }
-    }
-
-    fn set_backlight(&mut self, backlight: State) {
-        if let Some(bl_pin) = self.bl_pin.as_mut() {
-            match backlight {
-                State::Off => bl_pin.set_low().unwrap(),
-                State::On => bl_pin.set_high().unwrap(),
-            }
-        }
-    }
+    backlight_fns!();
 
     fn send(&mut self, command: Command) -> Option<u8> {
         assert!(
@@ -174,12 +261,15 @@ where
             }
         }
 
-        match command.get_read_write_op() {
-            ReadWriteOp::Write => {
-                self.rw_pin.set_low().ok().unwrap();
-            }
-            ReadWriteOp::Read => {
-                self.rw_pin.set_high().ok().unwrap();
+        {
+            let rw_pin = self.rw_pin.as_mut().expect("RW pin for readable");
+            match command.get_read_write_op() {
+                ReadWriteOp::Write => {
+                    rw_pin.set_low().ok().unwrap();
+                }
+                ReadWriteOp::Read => {
+                    rw_pin.set_high().ok().unwrap();
+                }
             }
         }
 
@@ -242,5 +332,79 @@ where
                 _ => unreachable!(),
             },
         }
+    }
+}
+
+impl<ControlPin, DBPin, BLPin, const PIN_CNT: usize, Delayer> SendCommand<Delayer, false>
+    for ParallelSender<ControlPin, DBPin, BLPin, PIN_CNT, false>
+where
+    ControlPin: OutputPin,
+    DBPin: OutputPin,
+    BLPin: StatefulOutputPin,
+    Delayer: DelayNs,
+{
+    backlight_fns!();
+
+    fn send(&mut self, command: Command) -> Option<u8> {
+        assert!(
+            PIN_CNT == 4 || PIN_CNT == 8,
+            "Pins other than 4 or 8 are not supported"
+        );
+
+        self.en_pin.set_low().ok().unwrap();
+
+        match command.get_register_selection() {
+            RegisterSelection::Command => {
+                self.rs_pin.set_low().ok().unwrap();
+            }
+            RegisterSelection::Data => {
+                self.rs_pin.set_high().ok().unwrap();
+            }
+        }
+
+        match command.get_read_write_op() {
+            ReadWriteOp::Write => {
+                let bits = command
+                    .get_data()
+                    .expect("Write command but no data provide");
+                match PIN_CNT {
+                    4 => match bits {
+                        Bits::Bit4(raw_bits) => {
+                            assert!(raw_bits < 2u8.pow(4), "data is greater than 4 bits");
+                            self.push_bits(raw_bits);
+                            self.en_pin.set_high().ok().unwrap();
+                            self.en_pin.set_low().ok().unwrap();
+                        }
+                        Bits::Bit8(raw_bits) => {
+                            self.push_bits(raw_bits >> 4);
+                            self.en_pin.set_high().ok().unwrap();
+                            self.en_pin.set_low().ok().unwrap();
+                            self.push_bits(raw_bits & 0b1111);
+                            self.en_pin.set_high().ok().unwrap();
+                            self.en_pin.set_low().ok().unwrap();
+                        }
+                    },
+
+                    8 => {
+                        if let Bits::Bit8(raw_bits) = bits {
+                            self.push_bits(raw_bits);
+                            self.en_pin.set_high().ok().unwrap();
+                            self.en_pin.set_low().ok().unwrap();
+                        } else {
+                            panic!("in 8 pin mode, data should always be 8 bit")
+                        }
+                    }
+
+                    _ => unreachable!(),
+                }
+
+                None
+            }
+            ReadWriteOp::Read => unreachable!(),
+        }
+    }
+
+    fn check_busy(&mut self) -> bool {
+        false
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,11 +38,6 @@ impl LcdState {
     }
 
     pub(crate) fn set_line_mode(&mut self, line: LineMode) {
-        assert!(
-            (self.get_font() == Font::Font5x11) && (line == LineMode::OneLine),
-            "font is 5x11, line cannot be 2"
-        );
-
         self.line = line;
     }
 
@@ -58,11 +53,6 @@ impl LcdState {
     }
 
     pub(crate) fn set_font(&mut self, font: Font) {
-        assert!(
-            (self.get_line_mode() == LineMode::TwoLine) && (font == Font::Font5x8),
-            "there is 2 line, font cannot be 5x11"
-        );
-
         self.font = font;
     }
 


### PR DESCRIPTION
The current version of the library only supports read/write operations, but you don't need to be able to read for the LCD to work. This PR adds a type-safe write-only mode to address this.